### PR TITLE
feat(datastructures): add detailed examples for list, dict, set, and tuple

### DIFF
--- a/datastructures/dictionaries.py
+++ b/datastructures/dictionaries.py
@@ -1,0 +1,33 @@
+# DICTIONARIES IN PYTHON
+
+# A dictionary stores data in key-value pairs.
+
+student = {
+    "name": "Alice",
+    "age": 21,
+    "major": "Computer Science"
+}
+
+print("Student dictionary:", student)
+
+# Accessing values
+print("Name:", student["name"])
+
+# Adding new key-value pair
+student["grade"] = "A"
+print("After adding grade:", student)
+
+# Updating value
+student["age"] = 22
+
+# Removing a key
+del student["major"]
+print("After deletion:", student)
+
+# Looping through dictionary
+for key, value in student.items():
+    print(f"{key} → {value}")
+
+# MEMO:
+# - Keys must be unique and immutable
+# - Very useful for structured data

--- a/datastructures/lists.py
+++ b/datastructures/lists.py
@@ -1,0 +1,37 @@
+# LISTS IN PYTHON
+
+# A list is an ordered, mutable collection of elements.
+
+fruits = ["apple", "banana", "cherry"]
+print("Original list:", fruits)
+
+# Accessing elements
+print("First fruit:", fruits[0])
+
+# Modifying elements
+fruits[1] = "mango"
+print("Modified list:", fruits)
+
+# Adding elements
+fruits.append("orange")
+print("After append:", fruits)
+
+# Inserting at specific position
+fruits.insert(1, "grape")
+print("After insert:", fruits)
+
+# Removing elements
+fruits.remove("cherry")
+print("After remove:", fruits)
+
+# Looping through list
+for fruit in fruits:
+    print("Fruit:", fruit)
+
+# List comprehension
+uppercase_fruits = [f.upper() for f in fruits]
+print("Uppercase fruits:", uppercase_fruits)
+
+# MEMO:
+# - Lists are mutable
+# - Use indexing, slicing, and list methods to manipulate

--- a/datastructures/sets.py
+++ b/datastructures/sets.py
@@ -1,0 +1,26 @@
+# SETS IN PYTHON
+
+# A set is an unordered collection of unique elements.
+
+unique_numbers = {1, 2, 3, 4, 5}
+print("Original set:", unique_numbers)
+
+# Adding elements
+unique_numbers.add(6)
+print("After add:", unique_numbers)
+
+# Removing elements
+unique_numbers.discard(3)
+print("After discard:", unique_numbers)
+
+# Set operations
+evens = {2, 4, 6, 8}
+odds = {1, 3, 5, 7}
+
+print("Union:", evens.union(odds))
+print("Intersection:", evens.intersection(unique_numbers))
+print("Difference:", evens.difference(unique_numbers))
+
+# MEMO:
+# - Sets do not allow duplicates
+# - Great for membership tests and set algebra

--- a/datastructures/tuples.py
+++ b/datastructures/tuples.py
@@ -1,0 +1,22 @@
+# TUPLES IN PYTHON
+
+# A tuple is an ordered, immutable collection of items.
+
+coordinates = (10, 20)
+print("Tuple:", coordinates)
+
+# Accessing elements
+print("X:", coordinates[0])
+print("Y:", coordinates[1])
+
+# Tuple unpacking
+x, y = coordinates
+print("Unpacked X and Y:", x, y)
+
+# Single-element tuple
+single = (5,)
+print("Single-element tuple:", single)
+
+# MEMO:
+# - Tuples are immutable → values cannot be changed
+# - Useful for fixed-size data (e.g., coordinates)


### PR DESCRIPTION
This PR adds the full implementation of the `datastructures/` folder, covering Python’s core built-in data structures with beginner-friendly examples and thorough explanations.

### What's Included:
- ✅ `lists.py`: Creation, modification, iteration, and list comprehension
- ✅ `dictionaries.py`: Key-value access, addition, update, deletion, and looping
- ✅ `sets.py`: Unique element handling, basic set operations (union, intersection, etc.)
- ✅ `tuples.py`: Immutable sequences, tuple unpacking, and single-element syntax

Each file is well-commented for self-learning, review, and teaching purposes.

Ready to be merged into `content-dev` as part of the ongoing Python syntax training repo.
