### PR TITLE
Add knight shortest path algorithm using BFS

### DIFF
--- a/datastructures/lists.py
+++ b/datastructures/lists.py
@@ -2,8 +2,10 @@
 
 # A list is an ordered, mutable collection of elements.
 
-fruits = ["apple", "banana", "cherry"]
+fruits = ["apple", "banana", "cherry", "peachh"]
 print("Original list:", fruits)
+print(fruits[1:])
+print(fruits[1:3])
 
 # Accessing elements
 print("First fruit:", fruits[0])

--- a/problem_solving/knight's_shortest_path.py
+++ b/problem_solving/knight's_shortest_path.py
@@ -1,0 +1,49 @@
+from collections import deque
+
+# Kata: Knight's Shortest Path
+# Given two different positions on a chess board,
+# find the least number of moves it would take a knight to get from one to the other.
+# The positions are passed as two arguments in algebraic notation, e.g., "a3", "b5".
+# The knight can only make valid chess moves and is not allowed to move off the 8x8 board.
+
+def knight(p1, p2):
+    # Convert a position like "a3" to (x, y) coordinates (0-indexed)
+    def to_coords(pos):
+        file = ord(pos[0]) - ord('a')  # 'a'-'h' becomes 0-7
+        rank = int(pos[1]) - 1         # '1'-'8' becomes 0-7
+        return (file, rank)
+
+    start = to_coords(p1)
+    target = to_coords(p2)
+
+    # If the starting and target positions are the same, no moves needed
+    if start == target:
+        return 0
+
+    # All 8 possible knight moves (L-shaped moves)
+    directions = [
+        (2, 1), (1, 2), (-1, 2), (-2, 1),
+        (-2, -1), (-1, -2), (1, -2), (2, -1)
+    ]
+
+    # Initialize visited matrix and queue for BFS
+    visited = [[False for _ in range(8)] for _ in range(8)]
+    queue = deque([(start[0], start[1], 0)])  # (x, y, move count)
+    visited[start[0]][start[1]] = True
+
+    # Perform BFS to find the shortest path
+    while queue:
+        x, y, moves = queue.popleft()
+
+        for dx, dy in directions:
+            nx, ny = x + dx, y + dy
+
+            # Check if the new position is within the board and not yet visited
+            if 0 <= nx < 8 and 0 <= ny < 8 and not visited[nx][ny]:
+                if (nx, ny) == target:
+                    return moves + 1  # Found the shortest path
+                visited[nx][ny] = True
+                queue.append((nx, ny, moves + 1))
+
+    # This should not be reached with valid inputs
+    return -1

--- a/problem_solving/prime_number.py
+++ b/problem_solving/prime_number.py
@@ -19,3 +19,4 @@ def list_primes_up_to(limit):
 if __name__ == "__main__":
     number = 30
     print(f"Prime numbers up to {number}: {list_primes_up_to(number)}")
+    


### PR DESCRIPTION
This pull request adds a Python implementation of the knight shortest path finder on a standard 8x8 chessboard.  
It solves the kata where, given two positions in algebraic notation (e.g., "a3", "b5"), we must calculate the least number of valid knight moves to travel from the start to the end.

### Approach
- Used Breadth-First Search (BFS) to ensure the shortest path is found efficiently.
- Converted algebraic notation to 0-indexed board coordinates.
- Handled all 8 possible knight moves and ensured positions stay within bounds.

### Example
```python
knight("a3", "b5")  # returns 1
knight("a1", "h8")  # returns 6
